### PR TITLE
Prevent multiple operators from being added consecutively

### DIFF
--- a/js/renderer.js
+++ b/js/renderer.js
@@ -113,8 +113,16 @@ function insertAtCursor(char) {
       current = current.slice(0, caretPos) + '×' + char + current.slice(caretPos);
       caretPos += 2;
     } else {
-      current = current.slice(0, caretPos) + char + current.slice(caretPos);
-      caretPos += char.length;
+    const operators = ['+', '-', '×', '÷', '*', '/'];
+    const prevChar = current[caretPos - 1];
+
+    if (operators.includes(char) && operators.includes(prevChar)) {
+      // Replace the previous operator with the new one
+      current = current.slice(0, caretPos - 1) + char + current.slice(caretPos);
+      } else {
+        current = current.slice(0, caretPos) + char + current.slice(caretPos);
+        caretPos += char.length;
+      }
     }
   }
 }


### PR DESCRIPTION
### Bug
When a user types a number followed by multiple operator buttons (e.g., `89×÷-+`), the calculator appends all of them. This leads to invalid input.

### Steps to Reproduce
1. Enter `89`
2. Press multiple operators in a row: `×`, `÷`, `-`, `+`
3. Output becomes: `89×÷-+`

### Expected Behavior
Only the most recent operator should remain. Others should be replaced.

### Suggested Fix
Modify the `insertAtCursor(char)` function to check:
- If the previous character is an operator
- If so, replace it with the new one

### Proposed Code
```js
const operators = ['+', '-', '×', '÷', '*', '/'];
const prevChar = current[caretPos - 1];

if (operators.includes(char) && operators.includes(prevChar)) {
  current = current.slice(0, caretPos - 1) + char + current.slice(caretPos);
} else {
  current = current.slice(0, caretPos) + char + current.slice(caretPos);
  caretPos += char.length;
}